### PR TITLE
Improve investment results UI and Sankey rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="el">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Υπολογιστής Επενδυτικού Εισοδήματος</title>
+    <link rel="stylesheet" href="styles.css">
+    <script src="https://www.gstatic.com/charts/loader.js"></script>
+</head>
+<body>
+    <main class="page">
+        <header class="hero">
+            <div class="hero__content">
+                <p class="eyebrow">Σύγχρονη φορολογική ανάλυση</p>
+                <h1>Επενδυτικό εισόδημα &amp; φορολογική επίπτωση</h1>
+                <p class="lede">Ρυθμίστε τα ποσά και τους φορολογικούς συντελεστές για τα διαφορετικά ρεύματα εισοδήματος και δείτε πώς κατανέμεται το τελικό καθαρό ποσό.</p>
+            </div>
+        </header>
+
+        <section class="panel">
+            <form id="investment-form" class="form" autocomplete="off">
+                <h2 class="panel__title">Παράμετροι επενδύσεων</h2>
+                <p class="panel__hint">Οι αριθμοί ενημερώνουν τα αποτελέσματα σε πραγματικό χρόνο. Πατήστε σε ένα πεδίο για να αντικαταστήσετε γρήγορα την τιμή του.</p>
+
+                <div class="form-grid">
+                    <fieldset class="stream" data-stream="dividends">
+                        <legend>Μερίσματα</legend>
+                        <label class="field">
+                            <span>Ποσό (€)</span>
+                            <input type="number" name="dividendsAmount" step="0.01" min="0" value="100" data-select-on-focus>
+                        </label>
+                        <label class="field">
+                            <span>Φόρος (%)</span>
+                            <input type="number" name="dividendsRate" step="0.01" min="0" value="5" data-select-on-focus>
+                        </label>
+                    </fieldset>
+
+                    <fieldset class="stream" data-stream="interest">
+                        <legend>Τόκοι</legend>
+                        <label class="field">
+                            <span>Ποσό (€)</span>
+                            <input type="number" name="interestAmount" step="0.01" min="0" value="50" data-select-on-focus>
+                        </label>
+                        <label class="field">
+                            <span>Φόρος (%)</span>
+                            <input type="number" name="interestRate" step="0.01" min="0" value="15" data-select-on-focus>
+                        </label>
+                    </fieldset>
+
+                    <fieldset class="stream" data-stream="capitalGains">
+                        <legend>Κεφαλαιακά κέρδη</legend>
+                        <label class="field">
+                            <span>Ποσό (€)</span>
+                            <input type="number" name="capitalGainsAmount" step="0.01" min="0" value="10000" data-select-on-focus>
+                        </label>
+                        <label class="field">
+                            <span>Φόρος (%)</span>
+                            <input type="number" name="capitalGainsRate" step="0.01" min="0" value="15" data-select-on-focus>
+                        </label>
+                    </fieldset>
+
+                    <fieldset class="stream" data-stream="royalties">
+                        <legend>Δικαιώματα</legend>
+                        <label class="field">
+                            <span>Ποσό (€)</span>
+                            <input type="number" name="royaltiesAmount" step="0.01" min="0" value="10" data-select-on-focus>
+                        </label>
+                        <label class="field">
+                            <span>Φόρος (%)</span>
+                            <input type="number" name="royaltiesRate" step="0.01" min="0" value="20" data-select-on-focus>
+                        </label>
+                    </fieldset>
+                </div>
+            </form>
+        </section>
+
+        <section class="panel results" aria-live="polite">
+            <header class="results__header">
+                <h2 class="panel__title">Επενδυτικά εισοδήματα</h2>
+                <p class="panel__hint">Συνολική εικόνα, σύγκριση φόρου και καθαρού ποσού και λεπτομερής ανάλυση ανά ροή εισοδήματος.</p>
+            </header>
+
+            <div class="results__summary">
+                <article class="summary-card">
+                    <h3>Ακαθάριστο εισόδημα</h3>
+                    <p class="summary-card__value" data-role="gross"></p>
+                </article>
+                <article class="summary-card summary-card--accent">
+                    <h3>Φόρος</h3>
+                    <p class="summary-card__value" data-role="tax"></p>
+                </article>
+                <article class="summary-card summary-card--success">
+                    <h3>Καθαρή επίδραση</h3>
+                    <p class="summary-card__value" data-role="net"></p>
+                </article>
+            </div>
+
+            <div class="results__grid">
+                <section class="chart-card">
+                    <div class="chart-card__header">
+                        <h3>Sankey διάγραμμα</h3>
+                        <p>Απεικονίζει τη ροή του εισοδήματος προς τον φόρο και το καθαρό υπόλοιπο.</p>
+                    </div>
+                    <div class="chart-shell">
+                        <div id="sankey-chart" role="img" aria-label="Διάγραμμα ροής φορολογικής κατανομής"></div>
+                        <p class="chart-placeholder" data-role="chart-placeholder">Εισάγετε ποσά για να δημιουργηθεί το διάγραμμα ροής.</p>
+                    </div>
+                </section>
+
+                <section class="analysis-card">
+                    <div class="analysis-card__header">
+                        <h3>Ανάλυση</h3>
+                        <p>Συγκριτική ματιά στο ποσό, στον φόρο και στο καθαρό αποτέλεσμα για κάθε κατηγορία.</p>
+                    </div>
+                    <div class="analysis-card__body" data-role="breakdown"></div>
+                </section>
+            </div>
+        </section>
+    </main>
+
+    <script type="module" src="scripts/calculator.js"></script>
+</body>
+</html>

--- a/scripts/calculator.js
+++ b/scripts/calculator.js
@@ -1,0 +1,293 @@
+import { attachAutoSelectHandlers } from './input-select-on-focus.js';
+
+const currencyFormatter = new Intl.NumberFormat('el-GR', {
+  style: 'currency',
+  currency: 'EUR',
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+const percentageFormatter = new Intl.NumberFormat('el-GR', {
+  style: 'percent',
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 1,
+});
+
+const FORM_STREAMS = [
+  { key: 'dividends', label: 'Μερίσματα', amountField: 'dividendsAmount', rateField: 'dividendsRate' },
+  { key: 'interest', label: 'Τόκοι', amountField: 'interestAmount', rateField: 'interestRate' },
+  { key: 'capitalGains', label: 'Κεφαλαιακά κέρδη', amountField: 'capitalGainsAmount', rateField: 'capitalGainsRate' },
+  { key: 'royalties', label: 'Δικαιώματα', amountField: 'royaltiesAmount', rateField: 'royaltiesRate' },
+];
+
+const form = document.querySelector('#investment-form');
+const resultsSection = document.querySelector('.results');
+const grossEl = resultsSection?.querySelector('[data-role="gross"]');
+const taxEl = resultsSection?.querySelector('[data-role="tax"]');
+const netEl = resultsSection?.querySelector('[data-role="net"]');
+const breakdownContainer = resultsSection?.querySelector('[data-role="breakdown"]');
+const chartContainer = document.querySelector('#sankey-chart');
+const chartPlaceholder = resultsSection?.querySelector('[data-role="chart-placeholder"]');
+
+let currentBreakdown = [];
+let sankeyChart;
+let googleChartsReady = null;
+let lastDrawnWidth = 0;
+
+function ensureGoogleChartsLoaded() {
+  if (!googleChartsReady) {
+    googleChartsReady = new Promise((resolve) => {
+      const loadCharts = () => {
+        google.charts.load('current', { packages: ['sankey'] });
+        google.charts.setOnLoadCallback(() => resolve());
+      };
+
+      if (window.google?.charts) {
+        loadCharts();
+        return;
+      }
+
+      const loaderScript = document.querySelector('script[src*="loader.js"]');
+      if (!loaderScript) {
+        resolve();
+        return;
+      }
+
+      loaderScript.addEventListener('load', loadCharts, { once: true });
+    });
+  }
+
+  return googleChartsReady;
+}
+
+function clampToNonNegative(value) {
+  return Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+function normalisePercentage(value) {
+  if (!Number.isFinite(value) || value < 0) {
+    return 0;
+  }
+
+  return value;
+}
+
+function readStreams() {
+  if (!form) {
+    return [];
+  }
+
+  return FORM_STREAMS.map((stream) => {
+    const amount = clampToNonNegative(Number.parseFloat(form.elements[stream.amountField]?.value));
+    const rate = normalisePercentage(Number.parseFloat(form.elements[stream.rateField]?.value));
+    const tax = amount * (rate / 100);
+    const net = amount - tax;
+
+    return {
+      key: stream.key,
+      label: stream.label,
+      amount,
+      rate,
+      tax,
+      net,
+    };
+  });
+}
+
+function formatPercent(value) {
+  return percentageFormatter.format(value / 100);
+}
+
+function updateSummaryCards(streams) {
+  if (!grossEl || !taxEl || !netEl) {
+    return;
+  }
+
+  const gross = streams.reduce((total, stream) => total + stream.amount, 0);
+  const totalTax = streams.reduce((total, stream) => total + stream.tax, 0);
+  const net = gross - totalTax;
+
+  grossEl.textContent = currencyFormatter.format(gross);
+  taxEl.textContent = currencyFormatter.format(totalTax);
+  netEl.textContent = currencyFormatter.format(net);
+}
+
+function createBreakdownRow(stream) {
+  const row = document.createElement('article');
+  row.className = 'breakdown-row';
+
+  row.innerHTML = `
+    <header class="breakdown-row__header">
+      <h4>${stream.label}</h4>
+      <span class="badge">${formatPercent(stream.rate)}</span>
+    </header>
+    <dl class="breakdown-row__metrics">
+      <div>
+        <dt>Ποσό</dt>
+        <dd>${currencyFormatter.format(stream.amount)}</dd>
+      </div>
+      <div>
+        <dt>Φόρος</dt>
+        <dd class="is-negative">-${currencyFormatter.format(stream.tax)}</dd>
+      </div>
+      <div>
+        <dt>Καθαρό</dt>
+        <dd class="is-positive">${currencyFormatter.format(stream.net)}</dd>
+      </div>
+    </dl>
+  `;
+
+  return row;
+}
+
+function renderBreakdown(streams) {
+  if (!breakdownContainer) {
+    return;
+  }
+
+  breakdownContainer.replaceChildren();
+
+  const activeStreams = streams.filter((stream) => stream.amount > 0);
+
+  if (!activeStreams.length) {
+    const emptyState = document.createElement('p');
+    emptyState.className = 'empty-state';
+    emptyState.textContent = 'Προσθέστε ποσά για να εμφανιστεί λεπτομερής ανάλυση κάθε κατηγορίας.';
+    breakdownContainer.appendChild(emptyState);
+    return;
+  }
+
+  activeStreams.forEach((stream) => breakdownContainer.appendChild(createBreakdownRow(stream)));
+}
+
+function buildSankeyData(streams) {
+  return streams
+    .filter((stream) => stream.amount > 0)
+    .flatMap((stream) => {
+      const rows = [];
+
+      if (stream.tax > 0) {
+        rows.push([stream.label, 'Φόρος', stream.tax]);
+      }
+
+      const netAmount = stream.net > 0 ? stream.net : 0;
+      if (netAmount > 0) {
+        rows.push([stream.label, 'Καθαρό', netAmount]);
+      }
+
+      return rows;
+    });
+}
+
+function drawSankey(force = false) {
+  if (!chartContainer) {
+    return;
+  }
+
+  if (!currentBreakdown.length) {
+    chartPlaceholder?.classList.remove('is-hidden');
+    chartContainer.replaceChildren();
+    return;
+  }
+
+  ensureGoogleChartsLoaded().then(() => {
+    if (!window.google || !google.visualization) {
+      return;
+    }
+
+    if (!sankeyChart) {
+      sankeyChart = new google.visualization.Sankey(chartContainer);
+    }
+
+    const dataTable = new google.visualization.DataTable();
+    dataTable.addColumn('string', 'Προέλευση');
+    dataTable.addColumn('string', 'Προορισμός');
+    dataTable.addColumn('number', 'Ποσό');
+    dataTable.addRows(buildSankeyData(currentBreakdown));
+
+    const width = Math.round(chartContainer.getBoundingClientRect().width);
+    if (width === 0) {
+      if (force) {
+        setTimeout(() => drawSankey(true), 120);
+      } else {
+        requestAnimationFrame(() => drawSankey(true));
+      }
+      return;
+    }
+
+    lastDrawnWidth = width;
+
+    chartPlaceholder?.classList.add('is-hidden');
+    const options = {
+      width,
+      height: 320,
+      backgroundColor: 'transparent',
+      sankey: {
+        node: {
+          label: {
+            color: '#e5edff',
+            fontSize: 14,
+            bold: true,
+          },
+          colors: ['#609bff', '#ff6b81', '#2bd4a8'],
+        },
+        link: {
+          colorMode: 'gradient',
+          colors: ['#4f76ff', '#ff5d6c', '#1bbb8a'],
+          opacity: 0.5,
+        },
+      },
+    };
+
+    sankeyChart.draw(dataTable, options);
+  });
+}
+
+function handleResize(entries) {
+  const entry = entries[0];
+  if (!entry) {
+    return;
+  }
+
+  const width = Math.round(entry.contentRect.width);
+  if (width === 0 || width === lastDrawnWidth) {
+    return;
+  }
+
+  drawSankey(true);
+}
+
+function render() {
+  const streams = readStreams();
+  currentBreakdown = streams.filter((stream) => stream.amount > 0);
+
+  updateSummaryCards(streams);
+  renderBreakdown(streams);
+  drawSankey();
+}
+
+function setup() {
+  if (!form || !resultsSection) {
+    return;
+  }
+
+  attachAutoSelectHandlers(form);
+
+  if (typeof ResizeObserver !== 'undefined' && chartContainer) {
+    const resizeObserver = new ResizeObserver(handleResize);
+    resizeObserver.observe(chartContainer);
+  } else {
+    window.addEventListener('resize', () => drawSankey(true));
+  }
+
+  form.addEventListener('input', render);
+  form.addEventListener('submit', (event) => event.preventDefault());
+
+  render();
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', setup);
+} else {
+  setup();
+}

--- a/scripts/input-select-on-focus.js
+++ b/scripts/input-select-on-focus.js
@@ -1,0 +1,31 @@
+function attachAutoSelectHandlers(root = document) {
+  const targets = root.querySelectorAll('[data-select-on-focus]');
+
+  targets.forEach((input) => {
+    // Skip elements that are not text-entry fields where selection makes sense.
+    if (!(input instanceof HTMLInputElement || input instanceof HTMLTextAreaElement)) {
+      return;
+    }
+
+    input.addEventListener('focus', () => {
+      input.select();
+      input.dataset.autoSelectActive = 'true';
+    });
+
+    // Prevent the mouseup event from clearing the programmatic selection when the user clicks once.
+    input.addEventListener('mouseup', (event) => {
+      if (input.dataset.autoSelectActive === 'true') {
+        event.preventDefault();
+        delete input.dataset.autoSelectActive;
+      }
+    });
+  });
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', () => attachAutoSelectHandlers(document));
+} else {
+  attachAutoSelectHandlers(document);
+}
+
+export { attachAutoSelectHandlers };

--- a/scripts/update-summary.js
+++ b/scripts/update-summary.js
@@ -1,0 +1,52 @@
+import { attachAutoSelectHandlers } from './input-select-on-focus.js';
+
+function describeScenario({ country, male, female, year }) {
+  const maleValue = Number.parseFloat(male);
+  const femaleValue = Number.parseFloat(female);
+
+  if (Number.isNaN(maleValue) || Number.isNaN(femaleValue)) {
+    return 'Provide both male and female enrollment percentages to see the comparison.';
+  }
+
+  const difference = femaleValue - maleValue;
+  const leadText = difference === 0
+    ? 'Male and female enrollment are identical.'
+    : difference > 0
+      ? `Female enrollment leads by ${difference.toFixed(1)} percentage points.`
+      : `Male enrollment leads by ${(Math.abs(difference)).toFixed(1)} percentage points.`;
+
+  const baseText = `${country || 'The selected country'} in ${year || 'the chosen year'} shows `;
+  return `${baseText}${leadText}`;
+}
+
+function updateSummary(section, form) {
+  const formData = new FormData(form);
+  const text = describeScenario({
+    country: formData.get('country')?.trim(),
+    male: formData.get('male'),
+    female: formData.get('female'),
+    year: formData.get('year'),
+  });
+
+  section.textContent = text;
+}
+
+function setupPage() {
+  const form = document.querySelector('.controls');
+  const summarySection = document.querySelector('.summary');
+
+  if (!form || !summarySection) {
+    return;
+  }
+
+  attachAutoSelectHandlers(form);
+  updateSummary(summarySection, form);
+
+  form.addEventListener('input', () => updateSummary(summarySection, form));
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', setupPage);
+} else {
+  setupPage();
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,380 @@
+* {
+  box-sizing: border-box;
+}
+
+:root {
+  color-scheme: dark;
+  font-family: 'Inter', 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  line-height: 1.5;
+  --page-max-width: 1200px;
+  --page-padding: clamp(2rem, 5vw, 3rem);
+  --panel-radius: 1.25rem;
+  --panel-bg: rgba(15, 28, 55, 0.7);
+  --panel-border: rgba(102, 123, 195, 0.25);
+  --panel-shadow: 0 24px 70px rgba(5, 12, 32, 0.65);
+  --surface-gradient: linear-gradient(135deg, rgba(96, 155, 255, 0.18), rgba(46, 212, 168, 0.12));
+  --accent: #5c8dff;
+  --accent-strong: #3a6bff;
+  --accent-soft: rgba(92, 141, 255, 0.12);
+  --danger: #ff6b81;
+  --success: #2bd4a8;
+  --text-primary: #eff4ff;
+  --text-muted: #9aa6d6;
+  --divider: rgba(111, 130, 196, 0.18);
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  background: radial-gradient(circle at top, #0f172a 0%, #050b1f 55%, #020412 100%);
+  color: var(--text-primary);
+}
+
+.page {
+  width: 100%;
+  max-width: var(--page-max-width);
+  padding: var(--page-padding);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.hero {
+  padding: 0.5rem 0 0;
+}
+
+.hero__content {
+  max-width: 620px;
+}
+
+.eyebrow {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.32em;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+h1 {
+  margin: 0.5rem 0;
+  font-size: clamp(2rem, 3vw, 2.8rem);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.lede {
+  margin: 0;
+  font-size: 1rem;
+  color: var(--text-muted);
+  max-width: 540px;
+}
+
+.panel {
+  background: var(--panel-bg);
+  border-radius: var(--panel-radius);
+  border: 1px solid var(--panel-border);
+  box-shadow: var(--panel-shadow);
+  padding: clamp(1.75rem, 3vw, 2.5rem);
+  backdrop-filter: blur(18px);
+}
+
+.panel__title {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 600;
+}
+
+.panel__hint {
+  margin: 0.35rem 0 1.5rem;
+  font-size: 0.95rem;
+  color: var(--text-muted);
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.form-grid {
+  display: grid;
+  gap: clamp(1rem, 2vw, 1.5rem);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.stream {
+  margin: 0;
+  padding: clamp(1rem, 2vw, 1.25rem);
+  border: 1px solid var(--divider);
+  border-radius: calc(var(--panel-radius) - 0.5rem);
+  background: var(--surface-gradient);
+  display: grid;
+  gap: 1rem;
+}
+
+.stream legend {
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+}
+
+.field span {
+  color: var(--text-muted);
+}
+
+.field input {
+  font: inherit;
+  font-size: 1rem;
+  padding: 0.65rem 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid transparent;
+  background: rgba(8, 15, 36, 0.65);
+  color: var(--text-primary);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.field input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 4px rgba(92, 141, 255, 0.25);
+  background: rgba(20, 38, 72, 0.85);
+}
+
+.results {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.75rem, 3vw, 2.5rem);
+}
+
+.results__summary {
+  display: grid;
+  gap: clamp(1rem, 2vw, 1.5rem);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.summary-card {
+  padding: clamp(1.25rem, 3vw, 1.75rem);
+  border-radius: calc(var(--panel-radius) - 0.5rem);
+  border: 1px solid var(--divider);
+  background: rgba(9, 18, 40, 0.9);
+  display: grid;
+  gap: 0.35rem;
+}
+
+.summary-card h3 {
+  margin: 0;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-muted);
+}
+
+.summary-card__value {
+  margin: 0;
+  font-size: clamp(1.5rem, 3vw, 1.9rem);
+  font-weight: 600;
+}
+
+.summary-card--accent {
+  background: linear-gradient(135deg, rgba(255, 107, 129, 0.15), rgba(255, 107, 129, 0.05));
+  border-color: rgba(255, 107, 129, 0.35);
+}
+
+.summary-card--accent .summary-card__value {
+  color: var(--danger);
+}
+
+.summary-card--success {
+  background: linear-gradient(135deg, rgba(43, 212, 168, 0.15), rgba(43, 212, 168, 0.05));
+  border-color: rgba(43, 212, 168, 0.35);
+}
+
+.summary-card--success .summary-card__value {
+  color: var(--success);
+}
+
+.results__grid {
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2rem);
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  align-items: start;
+}
+
+.chart-card,
+.analysis-card {
+  border: 1px solid var(--divider);
+  border-radius: calc(var(--panel-radius) - 0.5rem);
+  background: rgba(9, 18, 40, 0.85);
+  padding: clamp(1.25rem, 2.5vw, 1.75rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.chart-card__header h3,
+.analysis-card__header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.chart-card__header p,
+.analysis-card__header p {
+  margin: 0.35rem 0 0;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.chart-shell {
+  position: relative;
+  min-height: 320px;
+  border-radius: 1rem;
+  border: 1px dashed rgba(111, 130, 196, 0.25);
+  background: rgba(9, 18, 40, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+}
+
+#sankey-chart {
+  width: 100%;
+  height: 100%;
+}
+
+.chart-placeholder {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.95rem;
+  color: var(--text-muted);
+  background: transparent;
+  margin: 0;
+  text-align: center;
+  padding: 0 1.5rem;
+  transition: opacity 0.3s ease;
+}
+
+.chart-placeholder.is-hidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.analysis-card__body {
+  display: grid;
+  gap: 1rem;
+}
+
+.breakdown-row {
+  border-radius: 1rem;
+  background: rgba(11, 21, 45, 0.85);
+  border: 1px solid rgba(111, 130, 196, 0.25);
+  padding: 1rem 1.25rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.breakdown-row__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.breakdown-row__header h4 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.3rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  background: rgba(92, 141, 255, 0.15);
+  color: var(--accent);
+}
+
+.breakdown-row__metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.75rem;
+}
+
+.breakdown-row__metrics div {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.breakdown-row__metrics dt {
+  margin: 0;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+}
+
+.breakdown-row__metrics dd {
+  margin: 0;
+  font-weight: 600;
+}
+
+.breakdown-row__metrics .is-negative {
+  color: var(--danger);
+}
+
+.breakdown-row__metrics .is-positive {
+  color: var(--success);
+}
+
+.empty-state {
+  margin: 0;
+  padding: 1rem 1.25rem;
+  border-radius: 1rem;
+  border: 1px dashed rgba(111, 130, 196, 0.35);
+  color: var(--text-muted);
+  background: rgba(11, 21, 45, 0.55);
+  text-align: center;
+}
+
+@media (max-width: 720px) {
+  .hero__content {
+    max-width: none;
+  }
+
+  .summary-card__value {
+    font-size: 1.45rem;
+  }
+
+  .results__grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 520px) {
+  :root {
+    --panel-radius: 1rem;
+  }
+
+  .page {
+    padding: clamp(1.25rem, 5vw, 2rem);
+  }
+
+  .stream {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- redesign the main page into an investment income calculator with modern panels and localized copy
- add a calculator script that recalculates the tax breakdown, formats the results, and keeps the Sankey diagram full width via resize handling
- refresh the styling to present the summary cards, chart, and analysis list in a cohesive dark theme

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68de2b7ceaa48324becd671319536160